### PR TITLE
feature  stop ssl cert validation, which is troublesome for dev servers

### DIFF
--- a/corsa/proxy.py
+++ b/corsa/proxy.py
@@ -111,6 +111,7 @@ class ProxyHandler(tornado.web.RequestHandler):
             headers=self.request.headers,
             follow_redirects=False,
             allow_nonstandard_methods=True,
+            validate_cert=False, #for ssl dev servers that are using free dev certs
             use_gzip=False, # otherwise tornado will decode proxied data
         )
 


### PR DESCRIPTION
Dev servers often have custom generated certs as opposed to certs paid for by some authority like verisign. This feature enables the usage of these custom generated certs through the proxy service on HTTPS urls. 
